### PR TITLE
Add storage limits for all handled events

### DIFF
--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "0.76.1",
+      version: "0.76.2",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/andi/runtime.exs
+++ b/apps/andi/runtime.exs
@@ -37,7 +37,17 @@ config :andi, :brook,
   handlers: [Andi.Event.EventHandler],
   storage: [
     module: Brook.Storage.Redis,
-    init_arg: [redix_args: redix_args, namespace: "andi:view"]
+    init_arg: [redix_args: redix_args, namespace: "andi:view"],
+    event_limits: %{
+      "dataset:update" => 100,
+      "organization:update" => 100,
+      "user:organization:associate" => 100,
+      "data:ingest:end" => 100,
+      "dataset:delete" => 100,
+      "dataset:harvest:start" => 100,
+      "dataset:harvest:end" => 100,
+      "user:login" => 100
+    }
   ]
 
 config :andi, AndiWeb.Endpoint,

--- a/apps/discovery_api/mix.exs
+++ b/apps/discovery_api/mix.exs
@@ -5,7 +5,7 @@ defmodule DiscoveryApi.Mixfile do
     [
       app: :discovery_api,
       compilers: [:phoenix, :gettext | Mix.compilers()],
-      version: "0.55.2",
+      version: "0.55.3",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/discovery_api/runtime.exs
+++ b/apps/discovery_api/runtime.exs
@@ -113,7 +113,17 @@ config :discovery_api, :brook,
   handlers: [DiscoveryApi.Event.EventHandler],
   storage: [
     module: Brook.Storage.Redis,
-    init_arg: [redix_args: redix_args, namespace: "discovery-api:view"]
+    init_arg: [redix_args: redix_args, namespace: "discovery-api:view"],
+    event_limits: %{
+      "dataset:update" => 100,
+      "data:write:complete" => 100,
+      "dataset:query" => 100,
+      "organization:update" => 100,
+      "user:organization:associate" => 100,
+      "user:organization:disassociate" => 100,
+      "dataset:delete" => 100,
+      "user:login" => 100
+    }
   ]
 
 config :discovery_api, :elasticsearch,

--- a/apps/discovery_streams/mix.exs
+++ b/apps/discovery_streams/mix.exs
@@ -4,7 +4,7 @@ defmodule DiscoveryStreams.Mixfile do
   def project do
     [
       app: :discovery_streams,
-      version: "2.10.7",
+      version: "2.10.8",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/discovery_streams/runtime.exs
+++ b/apps/discovery_streams/runtime.exs
@@ -33,7 +33,12 @@ if kafka_brokers do
       module: Brook.Storage.Redis,
       init_arg: [
         redix_args: [host: redis_host],
-        namespace: "discovery_streams:view"
+        namespace: "discovery_streams:view",
+        event_limits: %{
+          "dataset:update" => 100,
+          "dataset:delete" => 100,
+          "data:ingest:start" => 100
+        }
       ]
     ]
 end

--- a/apps/forklift/mix.exs
+++ b/apps/forklift/mix.exs
@@ -4,7 +4,7 @@ defmodule Forklift.MixProject do
   def project do
     [
       app: :forklift,
-      version: "0.17.11",
+      version: "0.17.12",
       elixir: "~> 1.10",
       build_path: "../../_build",
       config_path: "../../config/config.exs",

--- a/apps/forklift/runtime.exs
+++ b/apps/forklift/runtime.exs
@@ -79,7 +79,15 @@ config :forklift, :brook,
     module: Brook.Storage.Redis,
     init_arg: [
       redix_args: redix_args,
-      namespace: "forklift:view"
+      namespace: "forklift:view",
+      event_limits: %{
+        "dataset:delete" => 100,
+        "dataset:update" => 100,
+        "data:write:complete" => 100,
+        "data:ingest:start" => 100,
+        "data:ingest:end" => 100,
+        "error:dataset:update" => 100
+      }
     ]
   ]
 

--- a/apps/odo/mix.exs
+++ b/apps/odo/mix.exs
@@ -4,7 +4,7 @@ defmodule Odo.MixProject do
   def project do
     [
       app: :odo,
-      version: "0.7.8",
+      version: "0.7.9",
       elixir: "~> 1.10",
       build_path: "../../_build",
       config_path: "../../config/config.exs",

--- a/apps/odo/runtime.exs
+++ b/apps/odo/runtime.exs
@@ -46,7 +46,14 @@ config :odo, :brook,
   handlers: [Odo.Event.EventHandler],
   storage: %{
     module: Brook.Storage.Redis,
-    init_arg: [redix_args: [host: redis_host], namespace: "odo:view"]
+    init_arg: [
+      redix_args: [host: redis_host],
+      namespace: "odo:view",
+      event_limits: %{
+        "file:ingest:end" => 100,
+        "error:file:ingest" => 100
+      }
+    ]
   }
 
   config :telemetry_event,

--- a/apps/reaper/mix.exs
+++ b/apps/reaper/mix.exs
@@ -4,7 +4,7 @@ defmodule Reaper.MixProject do
   def project do
     [
       app: :reaper,
-      version: "0.25.0",
+      version: "0.25.1",
       elixir: "~> 1.10",
       build_path: "../../_build",
       config_path: "../../config/config.exs",

--- a/apps/reaper/runtime.exs
+++ b/apps/reaper/runtime.exs
@@ -75,8 +75,15 @@ config :reaper, :brook,
       redix_args: redix_args,
       namespace: "reaper:view",
       event_limits: %{
-        "data:extract:start" => 1000,
-        "data:extract:end" => 1000
+        "data:extract:start" => 100,
+        "data:extract:end" => 100,
+        "data:ingest:start" => 100,
+        "file:ingest:start" => 100,
+        "file:ingest:end" => 100,
+        "error:dataset:update" => 100,
+        "dataset:update" => 100,
+        "dataset:disable" => 100,
+        "dataset:delete" => 100
       }
     ]
   },

--- a/apps/valkyrie/mix.exs
+++ b/apps/valkyrie/mix.exs
@@ -4,7 +4,7 @@ defmodule Valkyrie.MixProject do
   def project do
     [
       app: :valkyrie,
-      version: "1.6.7",
+      version: "1.6.8",
       elixir: "~> 1.10",
       build_path: "../../_build",
       config_path: "../../config/config.exs",

--- a/apps/valkyrie/runtime.exs
+++ b/apps/valkyrie/runtime.exs
@@ -60,7 +60,12 @@ if kafka_brokers do
     module: Brook.Storage.Redis,
     init_arg: [
       redix_args: redix_args,
-      namespace: "valkyrie:view"
+      namespace: "valkyrie:view",
+      event_limits: %{
+        "data:ingest:start" => 100,
+        "data:standardization:end" => 100,
+        "dataset:delete" => 100
+      }
     ]
   ]
 


### PR DESCRIPTION
+ Estuary does not use brook
+ Only handled events need this

Ref: https://github.com/Datastillery/smartcitiesdata/issues/1219