### PR TITLE
SMRT-1245 - Fix failing integration test

### DIFF
--- a/apps/andi/test/integration/andi_web/live/data_dictionary_form_test.exs
+++ b/apps/andi/test/integration/andi_web/live/data_dictionary_form_test.exs
@@ -571,12 +571,20 @@ defmodule AndiWeb.DataDictionaryFormTest do
 
       html = render_click(data_dictionary_view, "add_data_dictionary_field", %{})
 
-      assert [
-               {"Top Level", technical_id},
-               {"one", _},
-               {"one > one-one", new_eligible_parent_id},
-               {"two", _}
-             ] = get_all_select_options(html, ".data-dictionary-add-field-editor__parent-id select")
+      expected_options = [
+        "Top Level",
+        "one > one-one",
+        "one",
+        "two",
+      ]
+
+      select_options = get_all_select_options(html, ".data-dictionary-add-field-editor__parent-id select") 
+      
+      Enum.each(select_options, fn select_option ->
+        option_name = Tuple.to_list(select_option) |> Enum.at(0)
+        assert option_name in expected_options
+      end)
+      new_eligible_parent_id = List.keyfind(select_options, "one > one-one", 0) |> Tuple.to_list() |> Enum.at(1)
 
       add_field_form_data = %{
         "field" => %{

--- a/apps/andi/test/integration/andi_web/live/data_dictionary_form_test.exs
+++ b/apps/andi/test/integration/andi_web/live/data_dictionary_form_test.exs
@@ -575,15 +575,16 @@ defmodule AndiWeb.DataDictionaryFormTest do
         "Top Level",
         "one > one-one",
         "one",
-        "two",
+        "two"
       ]
 
-      select_options = get_all_select_options(html, ".data-dictionary-add-field-editor__parent-id select") 
-      
+      select_options = get_all_select_options(html, ".data-dictionary-add-field-editor__parent-id select")
+
       Enum.each(select_options, fn select_option ->
         option_name = Tuple.to_list(select_option) |> Enum.at(0)
         assert option_name in expected_options
       end)
+
       new_eligible_parent_id = List.keyfind(select_options, "one > one-one", 0) |> Tuple.to_list() |> Enum.at(1)
 
       add_field_form_data = %{

--- a/apps/andi/test/integration/andi_web/live/data_dictionary_form_test.exs
+++ b/apps/andi/test/integration/andi_web/live/data_dictionary_form_test.exs
@@ -580,12 +580,11 @@ defmodule AndiWeb.DataDictionaryFormTest do
 
       select_options = get_all_select_options(html, ".data-dictionary-add-field-editor__parent-id select")
 
-      Enum.each(select_options, fn select_option ->
-        option_name = Tuple.to_list(select_option) |> Enum.at(0)
+      Enum.each(select_options, fn {option_name, _} ->
         assert option_name in expected_options
       end)
 
-      new_eligible_parent_id = List.keyfind(select_options, "one > one-one", 0) |> Tuple.to_list() |> Enum.at(1)
+      {_, new_eligible_parent_id} = List.keyfind(select_options, "one > one-one", 0)
 
       add_field_form_data = %{
         "field" => %{


### PR DESCRIPTION
Updated andi integration test to ignore order of dictionary fields. 