### PR TITLE
Update runtime.exs to allow for configurable elasticsearch protocol

### DIFF
--- a/apps/discovery_api/mix.exs
+++ b/apps/discovery_api/mix.exs
@@ -5,7 +5,7 @@ defmodule DiscoveryApi.Mixfile do
     [
       app: :discovery_api,
       compilers: [:phoenix, :gettext | Mix.compilers()],
-      version: "1.1.0",
+      version: "1.2.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/discovery_api/runtime.exs
+++ b/apps/discovery_api/runtime.exs
@@ -129,8 +129,14 @@ config :discovery_api, :brook,
     ]
   ]
 
+elasticsearch_protocol =
+  case System.get_env("ELASTICSEARCH_TLS_ENABLED") do
+    "true" -> "https"
+    _ -> "http"
+  end
+
 config :discovery_api, :elasticsearch,
-  url: "https://" <> System.get_env("ELASTICSEARCH_HOST"),
+  url: "#{elasticsearch_protocol}://#{System.get_env("ELASTICSEARCH_HOST")}",
   indices: %{
     datasets: %{
       name: "datasets",


### PR DESCRIPTION
This is change can only be tested manually as it is only in runtime.exs (which is only run at runtime in packaged deployments). We validated it in sandbox against an elasticsearch instance without TLS enabled. 

This is a mild breaking change to any hypothetical other users of discovery-api