### PR TITLE
limit elasticsearch buckets for smaller installations

### DIFF
--- a/apps/discovery_api/lib/discovery_api/search/elasticsearch/query_builder.ex
+++ b/apps/discovery_api/lib/discovery_api/search/elasticsearch/query_builder.ex
@@ -4,7 +4,8 @@ defmodule DiscoveryApi.Search.Elasticsearch.QueryBuilder do
   """
   require Logger
 
-  @elasticsearch_max_buckets 2_147_483_647
+  # At maxiumum possible buckets (2_147_483_647) this can cause memory issues in ES
+  @elasticsearch_max_buckets 4_000_000
 
   def build(search_opts \\ []) do
     query_json = %{

--- a/apps/discovery_api/mix.exs
+++ b/apps/discovery_api/mix.exs
@@ -5,7 +5,7 @@ defmodule DiscoveryApi.Mixfile do
     [
       app: :discovery_api,
       compilers: [:phoenix, :gettext | Mix.compilers()],
-      version: "1.2.0",
+      version: "1.2.1",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",


### PR DESCRIPTION
At higher limits, this causes issues in some installations of elasticsearch.

No installation of discovery-api should have or return more than 4 million distinct buckets.