### PR TITLE
Typecast the provided port value

### DIFF
--- a/apps/discovery_streams/runtime.exs
+++ b/apps/discovery_streams/runtime.exs
@@ -3,6 +3,7 @@ use Mix.Config
 kafka_brokers = System.get_env("KAFKA_BROKERS")
 
 get_redix_args = fn host, password, port ->
+  port = if (port == ""), do: port, else: String.to_integer(port)
   [host: host, password: password, port: port]
   |> Enum.filter(fn
     {_, nil} -> false


### PR DESCRIPTION
Question: Should we worry about: receiving a string value in values.port, that can't be converted to an integer? Ex: "noodles"